### PR TITLE
Add timeline chart showing raw connectMbs values

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ Alongside the connectivity map and pie chart, the dashboard now also includes:
 
 - A bar chart showing the total time spent in green, orange and red zones.
 - A text indicator of the longest continuous duration in the green zone.
+- A timeline chart showing raw connectMbs values with station arrival markers.
 
 Dependencies are listed in `requirements.txt`.


### PR DESCRIPTION
## Summary
- visualize raw `connectmbs` values over time
- show station arrival timestamps on the timeline
- expose new plot in the Gradio interface
- document the new chart in the README

## Testing
- `python3 -m py_compile dashboard1.py`
- `python3 dashboard1.py` *(fails: ModuleNotFoundError: No module named 'gradio')*