### PR TITLE
Add side-by-side pie and bar charts

### DIFF
--- a/dashboard1.py
+++ b/dashboard1.py
@@ -450,8 +450,9 @@ with gr.Blocks() as demo:
 
     show_button = gr.Button("Afficher la carte")
     map_output = gr.Plot(label="Carte")
-    pie_output = gr.Plot(label="Qualité de la portion")
-    bar_output = gr.Plot(label="Durée continue par couleur")
+    with gr.Row():
+        pie_output = gr.Plot(label="Qualité de la portion")
+        bar_output = gr.Plot(label="Durée continue par couleur")
     chart_output = gr.Plot(label="Graphique choisi")
 
 


### PR DESCRIPTION
## Summary
- show pie chart and bar plot in the same row

## Testing
- `python -m py_compile dashboard1.py` *(fails: ModuleNotFoundError: No module named 'gradio')*