### PR TITLE
Add dashboard selector with placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,21 @@ This project provides an interactive Gradio dashboard to explore connectivity qu
 
 ## Usage
 
-Run the dashboard with:
+To access all available dashboards, run:
 
 ```bash
-python3 dashboard1.py
+python3 app.py
 ```
 
-The interface lets you choose the operator, direction, metric and a time range. Timestamps are selected with sliders but the chosen start and end times are displayed as readable dates just below the controls.
+The home page lets you switch between:
 
-Alongside the connectivity map and pie chart, the dashboard now also includes:
+- **Dashboard 1** – the original Trainways connectivity dashboard
+- **Dashboard 2** – placeholder for upcoming Zoom call data
+- **Dashboard 3** – placeholder for upcoming GNetTrack data
+
+The first dashboard lets you choose the operator, direction, metric and a time range. Timestamps are selected with sliders but the chosen start and end times are displayed as readable dates just below the controls.
+
+Alongside the connectivity map and pie chart, the dashboard also includes:
 
 - A bar chart indicating the longest continuous time (10 s steps) spent in the green, orange and red zones.
 - A filter to display either the distance or timestamp chart.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,27 @@
+import gradio as gr
+
+from dashboard1 import demo as dashboard1_app
+try:
+    from dashboard2 import demo as dashboard2_app
+except Exception:
+    dashboard2_app = gr.Blocks()
+    with dashboard2_app:
+        gr.Markdown("Dashboard 2 (Zoom) placeholder")
+try:
+    from dashboard3 import demo as dashboard3_app
+except Exception:
+    dashboard3_app = gr.Blocks()
+    with dashboard3_app:
+        gr.Markdown("Dashboard 3 (GNetTrack) placeholder")
+
+app = gr.TabbedInterface(
+    [dashboard1_app, dashboard2_app, dashboard3_app],
+    [
+        "Dashboard 1 - Trainways",
+        "Dashboard 2 - Zoom",
+        "Dashboard 3 - GNetTrack",
+    ],
+)
+
+if __name__ == "__main__":
+    app.launch()

--- a/dashboard2.py
+++ b/dashboard2.py
@@ -1,0 +1,10 @@
+"""Placeholder for Zoom call data dashboard."""
+
+import gradio as gr
+
+with gr.Blocks() as demo:
+    gr.Markdown("## Dashboard 2 - Zoom")
+    gr.Markdown("Interface en cours de développement.")
+
+if __name__ == "__main__":
+    demo.launch()

--- a/dashboard3.py
+++ b/dashboard3.py
@@ -1,0 +1,10 @@
+"""Placeholder for GNetTrack data dashboard."""
+
+import gradio as gr
+
+with gr.Blocks() as demo:
+    gr.Markdown("## Dashboard 3 - GNetTrack")
+    gr.Markdown("Interface en cours de développement.")
+
+if __name__ == "__main__":
+    demo.launch()


### PR DESCRIPTION
## Summary
- add an `app.py` to serve as a home page with tabs for three dashboards
- stub out `dashboard2.py` and `dashboard3.py`
- update README with new usage instructions

## Testing
- `python3 -m py_compile dashboard1.py dashboard2.py dashboard3.py app.py`